### PR TITLE
fix: evitar reescritura circular por capitalización

### DIFF
--- a/src/components/shared/CreditCard/CreditCard.tsx
+++ b/src/components/shared/CreditCard/CreditCard.tsx
@@ -49,6 +49,13 @@ const styles = StyleSheet.create({
 });
 
 const CreditCard = ({ cardHolder, dueDate, cardSuffix, bgColor, type, style }: CreditCardProps) => {
+  const checkDueMoment = (dueDate) => {
+    const dueMoment = moment(dueDate);
+    const Timezone = dueMoment.format('Z').slice(0, 3);
+    dueMoment.add(-Timezone, 'hours');
+    return dueMoment;
+  };
+  const dueMoment = checkDueMoment(dueDate);
   const dot = [styles.dot, { backgroundColor: styles.text.color }];
   return (
     <VStack shadow={7} style={[styles.card, { backgroundColor: bgColor }, style]}>
@@ -66,8 +73,9 @@ const CreditCard = ({ cardHolder, dueDate, cardSuffix, bgColor, type, style }: C
         <Text style={styles.text}>{cardSuffix}</Text>
       </HStack>
       <HStack style={styles.footerContainer}>
-        <Text style={styles.text}>{cardHolder}</Text>
-        <Text style={styles.text}>{moment(dueDate).format('YYYY/MM')}</Text>
+        <Text style={styles.text}>{cardHolder.toUpperCase()}</Text>
+        <Text style={styles.text}>{dueMoment.format('YYYY/MM')}</Text>
+        {checkDueMoment}
       </HStack>
     </VStack>
   );

--- a/src/components/shared/FormInput.tsx
+++ b/src/components/shared/FormInput.tsx
@@ -15,6 +15,7 @@ interface FormInputProps {
   type?: 'text' | 'password' | undefined;
   iconLeft?: React.ReactElement<typeof Icon> | undefined;
   helpText?: string | undefined;
+  maxLength?: number | undefined;
 }
 
 const FormInput = ({
@@ -29,6 +30,7 @@ const FormInput = ({
   width = 'full',
   disabled = false,
   type = 'text',
+  maxLength,
 }: FormInputProps) => {
   return (
     <FormControl width={width}>
@@ -44,6 +46,7 @@ const FormInput = ({
         InputRightElement={icon}
         InputLeftElement={iconLeft}
         isDisabled={disabled}
+        maxLength={maxLength}
       />
       <FormControl.HelperText
         _text={{

--- a/src/screens/AddCard/AddCard.tsx
+++ b/src/screens/AddCard/AddCard.tsx
@@ -22,13 +22,16 @@ const AddCard = ({ navigation }: any) => {
   const { saveCard } = useCreditCards();
   const toast = useToast();
 
+  const CardMaxLength = 19;
+  const CVVMaxLength = 4;
+
   const cleanCreditCardNumber = (value: string) => {
     let result: string = '';
     if (value) {
-      result = value.replace(/\D/g, '').slice(0, 19);
+      result = value.replace(/\D/g, '').slice(0, CardMaxLength);
     }
     return result;
-  }
+  };
 
   interface ValidationResult {
     success: Boolean;
@@ -36,8 +39,8 @@ const AddCard = ({ navigation }: any) => {
   }
 
   const validateCardData = (card: NewCreditCard): ValidationResult => {
-    const CreditCardRegex = '^[0-9]{10,18}$';
-    const CVVRegex = '^[0-9]{3,4}$';
+    const CreditCardRegex = `^[0-9]{10,${CardMaxLength}}$`;
+    const CVVRegex = `^[0-9]{3,${CVVMaxLength}}$`;
     let result: ValidationResult = { message: '', success: true };
     if (!card.codigoDeSeguridad || !card.codigoDeSeguridad.match(CVVRegex))
       result = { message: 'El codigo de seguridad no es válido', success: false };
@@ -45,10 +48,9 @@ const AddCard = ({ navigation }: any) => {
       result = { message: 'La fecha de vencimiento no es válida', success: false };
     if (!card.tipo || !card.categoria || !card.numero || !card.numero.match(CreditCardRegex))
       result = { message: 'El número de tarjeta no es válido', success: false };
-    if (!card.titular)
-      result = { message: 'Ingrese el titular de la tarjeta', success: false };
+    if (!card.titular) result = { message: 'Ingrese el titular de la tarjeta', success: false };
     return result;
-  }
+  };
 
   const styles = StyleSheet.create({
     title: {
@@ -61,13 +63,11 @@ const AddCard = ({ navigation }: any) => {
       alignItems: 'center',
       justifyContent: 'center',
     },
-
   });
   return (
     <ScrollView>
       <Text style={styles.title}>Agregar tarjeta</Text>
       <Center style={styles.container}>
-
         <Box mt={2}>
           <CreditCard
             cardHolder={cardHolder}
@@ -78,7 +78,6 @@ const AddCard = ({ navigation }: any) => {
           />
         </Box>
         <Box safeArea p="2" maxW={['90%', '90%', '50%']} minW="290" justifyContent="center">
-
           <Heading mt="1" fontWeight="medium" size="xs">
             Por favor, complete los siguientes datos
           </Heading>
@@ -86,10 +85,10 @@ const AddCard = ({ navigation }: any) => {
             <FormInput
               label="Numero de tarjeta"
               placeholder="XXXX XXXX XXXX XXXX"
-              helpText='Ingrese el número de la tarjeta que desea agregar'
+              helpText="Ingrese el número de la tarjeta que desea agregar"
               keyboardType="numeric"
               value={cardNumber}
-
+              maxLength={CardMaxLength}
               onChangeText={(value) => {
                 setCardSuffix(value.slice(-4));
                 setCardType(value.slice(0, 1) === '4' ? 'VISA' : 'MASTERCARD');
@@ -104,20 +103,21 @@ const AddCard = ({ navigation }: any) => {
               placeholder="Nombre Apellido"
               keyboardType="default"
               value={cardHolder}
-              onChangeText={(value) => setCardHolder(value.toUpperCase())}
+              onChangeText={setCardHolder}
               iconLeft={<Icon as={<MaterialIcons name="person" />} size={5} ml="2" color="muted.400" />}
-              helpText='Ingrese el nombre y apellido como se ve en la tarjeta'
+              helpText="Ingrese el nombre y apellido como se ve en la tarjeta"
             />
-            <Box flexDirection={'row'} justifyContent='space-between' marginBottom={3}>
+            <Box flexDirection={'row'} justifyContent="space-between" marginBottom={3}>
               <FormInput
                 label="Vencimiento"
                 placeholder="AAAA-MM"
                 keyboardType="numeric"
+                maxLength={7}
                 width={'45%'}
                 value={cardDueDate}
-                onChangeText={(value) => setCardDueDate(moment(new Date(value)))}
+                onChangeText={value => setCardDueDate(moment(new Date(value)))}
                 iconLeft={<Icon as={<MaterialIcons name="date-range" />} size={5} ml="2" color="muted.400" />}
-                helpText='Año y mes'
+                helpText="Año y mes"
               />
 
               <FormInput
@@ -126,41 +126,45 @@ const AddCard = ({ navigation }: any) => {
                 keyboardType="numeric"
                 width={'45%'}
                 value={cardCVV}
-                onChangeText={(value) => setCardCVV(value.slice(0, 4))}
+                maxLength={CVVMaxLength}
+                onChangeText={setCardCVV}
                 iconLeft={<Icon as={<MaterialIcons name="credit-card" />} size={5} ml="2" color="muted.400" />}
-                helpText='Código de seguridad'
+                helpText="Código de seguridad"
               />
             </Box>
-            <ActionButton text="Guardar" handlePress={() => {
-              let card: NewCreditCard = {
-                categoria: cardCategory,
-                titular: cardHolder,
-                fechaVencimiento: cardDueDate,
-                codigoDeSeguridad: cardCVV,
-                numero: cardNumber,
-                tipo: cardType,
-              }
-              let result: ValidationResult;
-              result = validateCardData(card)
-              if (result.success) {
-                saveCard(card).then((response) => {
-                  if (response) {
-                    navigation.navigate('MyCards');
-                  } else {
-                    result = {
-                      success: false,
-                      message: 'Error al guardar la tarjeta'
+            <ActionButton
+              text="Guardar"
+              handlePress={() => {
+                let card: NewCreditCard = {
+                  categoria: cardCategory,
+                  titular: cardHolder,
+                  fechaVencimiento: cardDueDate,
+                  codigoDeSeguridad: cardCVV,
+                  numero: cardNumber,
+                  tipo: cardType,
+                };
+                let result: ValidationResult;
+                result = validateCardData(card);
+                if (result.success) {
+                  saveCard(card).then((response) => {
+                    if (response) {
+                      navigation.navigate('MyCards');
+                    } else {
+                      result = {
+                        success: false,
+                        message: 'Error al guardar la tarjeta',
+                      };
                     }
-                  }
-                });
-              }
-              if (!result.success) {
-                toast.show({
-                  description: result.message,
-                  placement: 'top'
-                });
-              }
-            }} />
+                  });
+                }
+                if (!result.success) {
+                  toast.show({
+                    description: result.message,
+                    placement: 'top',
+                  });
+                }
+              }}
+            />
           </VStack>
         </Box>
       </Center>


### PR DESCRIPTION
• El campo titular de tarjeta capitalizaba el valor en cambios de texto, y en celulares con autocorrector activado, esto hacía que se agregara una palabra nueva cada vez que se agregaba texto y predecia la palabra siguiente. Se resolvió moviendo la capitalización al componente Tarjeta.
• Se agregaron longitudes máximas en tarjetas.
• Se arregló un error de muestra de fecha errónea en la tarjeta de crédito por reinterpretación de la zona horaria.